### PR TITLE
Hotfix/services: missing service imports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ add_service_files(
   FILES
   TopologicalPath.srv
   TopologicalPosition.srv
+  TopologicalMapInfo.srv
+  NodeInfo.srv
 )
 
 ## Generate added messages and services with any dependencies listed here

--- a/ros/src/topological_map_ros/topological_map.py
+++ b/ros/src/topological_map_ros/topological_map.py
@@ -7,7 +7,7 @@ import rospy
 
 import tf
 from geometry_msgs.msg import PoseWithCovarianceStamped
-from topological_map_ros.srv import TopologicalPath, TopologicalPathResponse, TopologicalPosition, TopologicalPositionResponse
+from topological_map_ros.srv import TopologicalPath, TopologicalPathResponse, TopologicalPosition, TopologicalPositionResponse, NodeInfo, TopologicalMapInfo
 
 
 def generate_map():
@@ -37,8 +37,8 @@ class TopologicalMap(object):
 
         self.path_server = rospy.Service('topological_path_plan', TopologicalPath, self.handle_path_request)
         self.position_server = rospy.Service('topological_position', TopologicalPosition, self.handle_position_request)
-        self.node_info_server = rospy.Service('topological_node_info', Area, self.handle_node_info_request)
-        self.map_server = rospy.Service('~topological_map_info', TopoMap, self.handle_map_info_request)
+        self.node_info_server = rospy.Service('topological_node_info', NodeInfi, self.handle_node_info_request)
+        self.map_server = rospy.Service('~topological_map_info', TopologicalMapInfo, self.handle_map_info_request)
 
         self.rooms_config = rospy.get_param('~rooms', dict())
 

--- a/ros/src/topological_map_ros/topological_map.py
+++ b/ros/src/topological_map_ros/topological_map.py
@@ -37,7 +37,7 @@ class TopologicalMap(object):
 
         self.path_server = rospy.Service('topological_path_plan', TopologicalPath, self.handle_path_request)
         self.position_server = rospy.Service('topological_position', TopologicalPosition, self.handle_position_request)
-        self.node_info_server = rospy.Service('topological_node_info', NodeInfi, self.handle_node_info_request)
+        self.node_info_server = rospy.Service('topological_node_info', NodeInfo, self.handle_node_info_request)
         self.map_server = rospy.Service('~topological_map_info', TopologicalMapInfo, self.handle_map_info_request)
 
         self.rooms_config = rospy.get_param('~rooms', dict())


### PR DESCRIPTION
The topological_server was not running properly because of missing service imports from changes in these two commits:

- [78f2a09979e61d0b6b3ab8f1a8a01ea02bb7fff6]
- [05e425266b438378b7b046d652446c9c36d21b75]
    - Area -> NodeInfo
    - TopoMap - > TopologicalMapInfo